### PR TITLE
Create Passport authentication strategy tailored for Thinkful.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,18 @@
+{
+  "node": true,
+  "bitwise": true,
+  "camelcase": true,
+  "curly": true,
+  "forin": true,
+  "immed": true,
+  "latedef": true,
+  "newcap": true,
+  "noarg": true,
+  "noempty": true,
+  "nonew": true,
+  "quotmark": "single",
+  "undef": true,
+  "unused": true,
+  "trailing": true,
+  "laxcomma": true
+}

--- a/README.md
+++ b/README.md
@@ -15,15 +15,15 @@ This module authenticates requests intended for Thinkful services. It wraps [htt
 
 ```javascript
 passport.use(new ThinkfulStrategy(
-	{ secret: publicPrivateSigningKey },
-	function (req, user, done) {
-  	request.get(USER_API_ENDPOINT)
-    	.set('Authorization', req.headers.authorization)
-    	.end(function (err, res) {
+  { secret: publicPrivateSigningKey },
+  function (req, user, done) {
+    request.get(USER_API_ENDPOINT)
+      .set('Authorization', req.headers.authorization)
+      .end(function (err, res) {
         if (err) { return done(err); }
         if (!res.body || !res.body.user) { return done(null, false); }
         return done(null, res.body.user);
-  		});
+      });
   }
 ));
 ```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,41 @@
 # passport-thinkful
-A Passport authentication strategy for Thinkful services.
+[![Circle CI](https://circleci.com/gh/Thinkful/passport-thinkful.svg?style=shield)](https://circleci.com/gh/Thinkful/passport-thinkful)
+
+Thinkful's authentication strategy for [Passport](http://passportjs.org/).
+
+This module authenticates requests intended for Thinkful services. It wraps [http-passport-bearer](//github.com/jaredhanson/passport-http-bearer) with a JWT verification step.
+
+## Install
+
+    $ npm install passport-thinkful
+
+## Usage
+
+#### Configure Strategy
+
+```javascript
+passport.use(new ThinkfulStrategy(
+	{ secret: publicPrivateSigningKey },
+	function (req, user, done) {
+  	request.get(USER_API_ENDPOINT)
+    	.set('Authorization', req.headers.authorization)
+    	.end(function (err, res) {
+        if (err) { return done(err); }
+        if (!res.body || !res.body.user) { return done(null, false); }
+        return done(null, res.body.user);
+  		});
+  }
+));
+```
+
+#### Authenticate Requests
+
+Use `passport.authenticate('thinkful')` to authenticate requests. JWT authorization tokens negate the need for sessions, so the `session` option should be set to `false`.
+
+An [Express](http://expressjs.com/) route middleware example:
+
+```javascript
+app.get('/users/me',
+  passport.authenticate('thinkful', { session: false }),
+  function(req, res) { res.json(req.user); }
+);

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+  node:
+    version: v0.12.0

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,14 @@
+/**
+ * Module Dependencies
+ */
+var Strategy = require('./strategy');
+
+/**
+ * Expose `Strategy` directly from package.
+ */
+exports = module.exports = Strategy;
+
+/**
+ * Exports constructors.
+ */
+exports.Strategy = Strategy;

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -8,15 +8,16 @@ var util = require('util')
 function ThinkfulStrategy (options, verify) {
   options = options || {};
 
-  HttpBearerStrategy.call(this, options, function verifyJWT (token, done) {
-    jsonwebtoken.verify(token, this._secret, function (err, userToken) {
+  HttpBearerStrategy.call(this, function verifyJWT (req, token, done) {
+    jsonwebtoken.verify(token, this._secret, function (err, user) {
       if (err) { return done(err, false); }
-      verify(userToken, done);
+      verify(req, user, done);
     });
   });
 
   this.name = 'thinkful';
   this._secret = options.secret;
+  this._passReqToCallback = true;
 }
 
 /**
@@ -25,18 +26,15 @@ function ThinkfulStrategy (options, verify) {
 util.inherits(ThinkfulStrategy, HttpBearerStrategy);
 
 ThinkfulStrategy.prototype.authenticate = function tfAuthenticate (req) {
-  var token =
-    req.headers.authorization ||
-    req.headers.Authorization ||
-    req.cookies['Tf-Authorization'];
+  var token = req.headers.authorization || req.cookies['Tf-Authorization'];
 
-  if (/^Bearer/.test(token)) {
+  if (!/^Bearer/.test(token)) {
     token = 'Bearer ' + token;
   }
 
   req.headers.authorization = token;
 
-  HttpBearerStrategy.authenticate.call(this, req);
+  HttpBearerStrategy.prototype.authenticate.call(this, req);
 };
 
 /**

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -64,11 +64,13 @@ function ThinkfulStrategy (options, verify) {
   options = options || {};
 
   BearerStrategy.call(this, function verifyJWT (req, token, done) {
+    var _this = this;
+
     jsonwebtoken.verify(token, this._secret, function (err, user) {
       if (err) {
-        return this.fail(400, err); }
+        return _this.fail(400, err); }
       try {
-        user = JSON.parse(user); } catch (e) { return this.fail(400) }
+        user = JSON.parse(user); } catch (e) { return _this.fail(400) }
 
       return verify(req, user, done);
     });

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -65,8 +65,12 @@ function ThinkfulStrategy (options, verify) {
 
   BearerStrategy.call(this, function verifyJWT (req, token, done) {
     jsonwebtoken.verify(token, this._secret, function (err, user) {
-      if (err) { return done(err, false); }
-      verify(req, user, done);
+      if (err) {
+        return this.fail(400, err); }
+      try {
+        user = JSON.parse(user); } catch (e) { return this.fail(400) }
+
+      return verify(req, user, done);
     });
   });
 
@@ -90,7 +94,10 @@ util.inherits(ThinkfulStrategy, BearerStrategy);
 ThinkfulStrategy.prototype.authenticate = function tfAuthenticate (req) {
   var token = req.headers.authorization || req.cookies['Tf-Authorization'];
 
-  if (!/^Bearer/.test(token)) {
+  if(!token) {
+    return this.fail(401)
+  }
+  else if (!/^Bearer/.test(token)) {
     token = 'Bearer ' + token;
   }
 

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -2,13 +2,68 @@
  * Module Dependencies
  */
 var util = require('util')
-  , HttpBearerStrategy = require('passport-http-bearer')
+  , BearerStrategy = require('passport-http-bearer')
   , jsonwebtoken = require('jsonwebtoken');
 
+
+/**
+ * Creates an instance of `HttpBearerStrategy`.
+ *
+ * The Thinkful authentication strategy authenticates requests based on the JWT
+ * token contained in the `Authorization` header field, the `Tf-Authorization`
+ * cookie, `access_token` body parameter, or `access_token` query parameter.
+ *
+ * We leverage passport-http-bearer for parsing and error handling. We provide a
+ * JWT specific verification call, and manipulate the request to support the
+ * `Tf-Authorization` cookie and correct for the missing `Bearer ` prefix on
+ * the token. (Remaining doc from passport-http-bearer)
+ *
+ * Applications must supply a `verify` callback, for which the function
+ * signature is:
+ *
+ *     function(token, done) { ... }
+ *
+ * `token` is the bearer token provided as a credential.  The verify callback
+ * is responsible for finding the user who posesses the token, and invoking
+ * `done` with the following arguments:
+ *
+ *     done(err, user, info);
+ *
+ * If the token is not valid, `user` should be set to `false` to indicate an
+ * authentication failure.  Additional token `info` can optionally be passed as
+ * a third argument, which will be set by Passport at `req.authInfo`, where it
+ * can be used by later middleware for access control.  This is typically used
+ * to pass any scope associated with the token.
+ *
+ * Options:
+ *
+ *   - `realm`  authentication realm, defaults to "Users"
+ *   - `scope`  list of scope values indicating the required scope of the access
+ *              token for accessing the requested resource
+ *
+ * Examples:
+ *
+ *     passport.use(new ThinkfulStrategy(
+ *       function(token, done) {
+ *         User.findByToken({ token: token }, function (err, user) {
+ *           if (err) { return done(err); }
+ *           if (!user) { return done(null, false); }
+ *           return done(null, user, { scope: 'read' });
+ *         });
+ *       }
+ *     ));
+ *
+ * For further details on HTTP Bearer authentication, refer to [The OAuth 2.0 Authorization Protocol: Bearer Tokens](http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer)
+ *
+ * @constructor
+ * @param {Object} [options]
+ * @param {Function} verify
+ * @api public
+ */
 function ThinkfulStrategy (options, verify) {
   options = options || {};
 
-  HttpBearerStrategy.call(this, function verifyJWT (req, token, done) {
+  BearerStrategy.call(this, function verifyJWT (req, token, done) {
     jsonwebtoken.verify(token, this._secret, function (err, user) {
       if (err) { return done(err, false); }
       verify(req, user, done);
@@ -21,10 +76,17 @@ function ThinkfulStrategy (options, verify) {
 }
 
 /**
- * Inherit from HttpBearerStrategy
+ * Inherit from BearerStrategy
  */
-util.inherits(ThinkfulStrategy, HttpBearerStrategy);
+util.inherits(ThinkfulStrategy, BearerStrategy);
 
+/**
+ * Authenticate request based on the contents of an `authorization` header,
+ * `Tf-Authorization` cookie, or `access_token` body/query parameter.
+ *
+ * @param {Object} req
+ * @api protected
+ */
 ThinkfulStrategy.prototype.authenticate = function tfAuthenticate (req) {
   var token = req.headers.authorization || req.cookies['Tf-Authorization'];
 
@@ -34,7 +96,7 @@ ThinkfulStrategy.prototype.authenticate = function tfAuthenticate (req) {
 
   req.headers.authorization = token;
 
-  HttpBearerStrategy.prototype.authenticate.call(this, req);
+  BearerStrategy.prototype.authenticate.call(this, req);
 };
 
 /**

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -1,0 +1,23 @@
+/**
+ * Module Dependencies
+ */
+var util = require('unit')
+  , PassportStrategy = require('passport-strategy');
+
+function ThinkfulStrategy (options, verify) {
+  options = options || {};
+
+  passport.Strategy.call(this);
+
+  this.name = 'thinkful';
+}
+
+/**
+ * Inherit from PassportStrategy
+ */
+util.inherits(ThinkfulStrategy, PassportStrategy);
+
+/**
+ * Expose `Strategy`.
+ */
+module.exports = ThinkfulStrategy;

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -1,14 +1,14 @@
 /**
  * Module Dependencies
  */
-var util = require('unit')
+var util = require('util')
   , HttpBearerStrategy = require('passport-http-bearer')
   , jsonwebtoken = require('jsonwebtoken');
 
 function ThinkfulStrategy (options, verify) {
   options = options || {};
 
-  HttpBearerStrategy.call(this, options, function _jwtVerify (token, done) {
+  HttpBearerStrategy.call(this, options, function verifyJWT (token, done) {
     jsonwebtoken.verify(token, this._secret, function (err, userToken) {
       if (err) { return done(err, false); }
       verify(userToken, done);

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -2,20 +2,42 @@
  * Module Dependencies
  */
 var util = require('unit')
-  , PassportStrategy = require('passport-strategy');
+  , HttpBearerStrategy = require('passport-http-bearer')
+  , jsonwebtoken = require('jsonwebtoken');
 
 function ThinkfulStrategy (options, verify) {
   options = options || {};
 
-  passport.Strategy.call(this);
+  HttpBearerStrategy.call(this, options, function _jwtVerify (token, done) {
+    jsonwebtoken.verify(token, this._secret, function (err, userToken) {
+      if (err) { return done(err, false); }
+      verify(userToken, done);
+    });
+  });
 
   this.name = 'thinkful';
+  this._secret = options.secret;
 }
 
 /**
- * Inherit from PassportStrategy
+ * Inherit from HttpBearerStrategy
  */
-util.inherits(ThinkfulStrategy, PassportStrategy);
+util.inherits(ThinkfulStrategy, HttpBearerStrategy);
+
+ThinkfulStrategy.prototype.authenticate = function tfAuthenticate (req) {
+  var token =
+    req.headers.authorization ||
+    req.headers.Authorization ||
+    req.cookies['Tf-Authorization'];
+
+  if (/^Bearer/.test(token)) {
+    token = 'Bearer ' + token;
+  }
+
+  req.headers.authorization = token;
+
+  HttpBearerStrategy.authenticate.call(this, req);
+};
 
 /**
  * Expose `Strategy`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-thinkful",
-  "version": "0.0.0-beta.2",
+  "version": "0.0.0-beta.3",
   "description": "Thinkful authentication strategy for Passport.",
   "main": "./lib",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "mocha": "^2.1.0"
   },
   "dependencies": {
-    "passport-strategy": "^1.0.0"
+    "jsonwebtoken": "^3.2.2",
+    "passport-http-bearer": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-thinkful",
-  "version": "0.0.0-beta.1",
+  "version": "0.0.0-beta.2",
   "description": "Thinkful authentication strategy for Passport.",
   "main": "./lib",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "passport-thinkful",
+  "version": "0.0.0",
+  "description": "Thinkful authentication strategy for Passport.",
+  "main": "./lib",
+  "scripts": {
+    "test": "mocha --reporter spec --require test/bootstrap/node test/*.test.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Thinkful/passport-thinkful.git"
+  },
+  "keywords": [
+    "passport",
+    "thinkful",
+    "auth"
+  ],
+  "author": "Thinkful",
+  "license": "Apache 2.0",
+  "bugs": {
+    "url": "https://github.com/Thinkful/passport-thinkful/issues"
+  },
+  "homepage": "https://github.com/Thinkful/passport-thinkful",
+  "devDependencies": {
+    "chai": "^1.10.0",
+    "chai-passport-strategy": "^0.2.0",
+    "mocha": "^2.1.0"
+  },
+  "dependencies": {
+    "passport-strategy": "^1.0.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-thinkful",
-  "version": "0.0.0",
+  "version": "0.0.0-beta.1",
   "description": "Thinkful authentication strategy for Passport.",
   "main": "./lib",
   "scripts": {

--- a/test/bootstrap/node.js
+++ b/test/bootstrap/node.js
@@ -1,0 +1,5 @@
+var chai = require('chai');
+
+chai.use(require('chai-passport-strategy'));
+
+global.expect = chai.expect;

--- a/test/package.test.js
+++ b/test/package.test.js
@@ -1,0 +1,16 @@
+/* global describe, it, expect */
+
+var strategy = require('..');
+
+describe('passport-thinkful', function() {
+
+  it('should export Strategy constructor directly from package', function() {
+    expect(strategy).to.be.a('function');
+    expect(strategy).to.equal(strategy.Strategy);
+  });
+
+  it('should export Strategy constructor', function() {
+    expect(strategy.Strategy).to.be.a('function');
+  });
+
+});

--- a/test/strategy.test.js
+++ b/test/strategy.test.js
@@ -1,0 +1,18 @@
+/* global describe, it, expect */
+/* jshint expr: true */
+
+var ThinkfulStrategy = require('../lib/strategy');
+
+
+describe('Strategy', function() {
+
+  var strategy = new ThinkfulStrategy({
+      clientID: 'ABC123',
+      clientSecret: 'secret'
+    },
+    function() {});
+
+  it('should be named thinkful', function() {
+    expect(strategy.name).to.equal('thinkful');
+  });
+});


### PR DESCRIPTION
This first iteration wraps `passport-http-bearer` with a JWT authentication step. It will also pick out the `Tf-Authorization` cookie if present and prefix `Bearer ` where missing.

Future iterations should include an option to request the user object from our API.